### PR TITLE
Support for intermediate positions (experimental)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -2,7 +2,7 @@
     "pluginAlias": "Selve",
     "pluginType": "accessory",
     "singular": false,
-    "headerDisplay": "*Important:* For this plugin to work, you'll need to first pair the Selve USB-RF module manually to all shutters!",
+    "headerDisplay": "*Important:* For this plugin to work, you'll need to first pair the Selve USB-RF module manually with all shutters!",
     "schema": {
         "type": "object",
         "properties": {
@@ -26,6 +26,20 @@
                 "default": 0,
                 "minimum": 0,
                 "maximum": 63
+            },
+            "intermediate1": {
+                "title": "Show intermediate position 1 (experimental)",
+                "description": "Show a toggle button to allow moving to intermediate position 1",
+                "type": "boolean",
+                "required": false,
+                "default": false
+            },
+            "intermediate2": {
+                "title": "Show intermediate position 2 (experimental)",
+                "description": "Show a toggle button to allow moving to intermediate position 2",
+                "type": "boolean",
+                "required": false,
+                "default": false
             }
         }
     },

--- a/config.schema.json
+++ b/config.schema.json
@@ -27,14 +27,14 @@
                 "minimum": 0,
                 "maximum": 63
             },
-            "intermediate1": {
+            "showIntermediate1": {
                 "title": "Show intermediate position 1 (experimental)",
                 "description": "Show a toggle button to allow moving to intermediate position 1",
                 "type": "boolean",
                 "required": false,
                 "default": false
             },
-            "intermediate2": {
+            "showIntermediate2": {
                 "title": "Show intermediate position 2 (experimental)",
                 "description": "Show a toggle button to allow moving to intermediate position 2",
                 "type": "boolean",

--- a/dist/data/commeo-state.js
+++ b/dist/data/commeo-state.js
@@ -1,12 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 class CommeoState {
-    constructor(device) {
+    constructor() {
         this.CurrentPosition = 100; // assume default open
         this.TargetPosition = 100; // assume default open
         this.PositionState = HomebridgePositionState.STOPPED;
         this.ObstructionDetected = false;
-        this.device = device;
     }
 }
 exports.CommeoState = CommeoState;

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,27 +9,38 @@ class SelveShutter {
         this.setTargetPosition = (newPosition, cb) => {
             this.log("Set new target position to", newPosition);
             this.state.TargetPosition = Number(newPosition);
-            this.usbService.sendPosition(this.state.device, this.state.TargetPosition, cb);
+            this.usbService.sendMovePosition(this.device, this.state.TargetPosition, cb);
+        };
+        this.setIntermediatePosition = (pos) => (value, cb) => {
+            if (!value) {
+                return cb();
+            }
+            this.log("Set to move to intermediate position", pos);
+            this.usbService.sendMoveIntermediatePosition(this.device, pos, cb);
         };
         this.getPositionState = (cb) => cb(null, this.state.PositionState);
         this.getObstructionDetected = (cb) => cb(null, this.state.ObstructionDetected);
         this.log = log;
         this.name = config.name;
+        this.config = config;
         // device config
         this.device = Number(config.device);
         if (this.device === undefined) {
-            throw new Error('Option "device" needs to be set');
+            throw new Error('Option "device" is required and needs to be set!');
         }
         // serial port config
         const port = config.port;
         if (port === undefined) {
-            throw new Error('Option "port" needs to be set');
+            throw new Error('Option "port" is required and needs to be set!');
         }
-        this.state = new commeo_state_1.CommeoState(this.device);
-        // setup services
+        this.state = new commeo_state_1.CommeoState();
+        // initialize services
         this.usbService = usb_rf_service_1.USBRfService.getInstance(port);
         this.shutterService = new hap.Service.WindowCovering(this.name);
         this.informationService = new hap.Service.AccessoryInformation();
+        this.switchService1 = new hap.Service.Switch('Position 1', '1');
+        this.switchService2 = new hap.Service.Switch('Position 2', '2');
+        // setup shutter services
         this.shutterService
             .getCharacteristic(hap.Characteristic.CurrentPosition)
             .on("get" /* GET */, this.getCurrentPosition.bind(this));
@@ -43,6 +54,13 @@ class SelveShutter {
         this.shutterService
             .getCharacteristic(hap.Characteristic.ObstructionDetected)
             .on("get" /* GET */, this.getObstructionDetected.bind(this));
+        // setup optional intermediate button services
+        this.switchService1
+            .getCharacteristic(hap.Characteristic.On)
+            .on("set" /* SET */, this.setIntermediatePosition(1).bind(this));
+        this.switchService2
+            .getCharacteristic(hap.Characteristic.On)
+            .on("set" /* SET */, this.setIntermediatePosition(2).bind(this));
         // setup info service
         this.informationService = new hap.Service.AccessoryInformation();
         if (config.manufacturer) {
@@ -57,29 +75,27 @@ class SelveShutter {
         // handle status updates
         this.usbService.eventEmitter.on(String(this.device), (newState) => {
             log("New status", newState);
-            if (newState.CurrentPosition !== undefined) {
-                this.shutterService.getCharacteristic(hap.Characteristic.CurrentPosition).setValue(newState.CurrentPosition);
-            }
-            if (newState.PositionState !== undefined) {
-                this.shutterService.getCharacteristic(hap.Characteristic.PositionState).setValue(newState.PositionState);
-            }
-            if (newState.ObstructionDetected !== undefined) {
-                this.shutterService.getCharacteristic(hap.Characteristic.ObstructionDetected).setValue(newState.ObstructionDetected);
-            }
-            // upgrade current state with new data
             this.state = {
                 ...this.state,
                 ...newState
             };
+            this.shutterService.getCharacteristic(hap.Characteristic.CurrentPosition).updateValue(this.state.CurrentPosition);
+            this.shutterService.getCharacteristic(hap.Characteristic.PositionState).updateValue(this.state.PositionState);
+            this.shutterService.getCharacteristic(hap.Characteristic.ObstructionDetected).updateValue(this.state.ObstructionDetected);
+            this.switchService1.getCharacteristic(hap.Characteristic.On).updateValue(false);
+            this.switchService2.getCharacteristic(hap.Characteristic.On).updateValue(false);
+            // upgrade current state with new data
         });
-        // get current position
+        // request current position
         this.usbService.requestUpdate(this.device, err => !!err && log.error(err.message));
     }
     getServices() {
         return [
             this.informationService,
             this.shutterService,
-        ];
+            this.config.showIntermediate1 ? this.switchService1 : null,
+            this.config.showIntermediate2 ? this.switchService2 : null
+        ].filter(s => !!s);
     }
 }
 module.exports = (api) => {

--- a/dist/util/usb-rf.service.js
+++ b/dist/util/usb-rf.service.js
@@ -100,9 +100,15 @@ class USBRfService {
     convertPositionToCommeo(homekitPos) {
         return homekitPos > 0 ? COMMEO_MAX_POSITION - Math.min(Math.round(homekitPos / 100 * COMMEO_MAX_POSITION), COMMEO_MAX_POSITION) : COMMEO_MAX_POSITION;
     }
-    sendPosition(device, targetPos, cb) {
+    sendMovePosition(device, targetPos, cb) {
         const commeoTargetPos = this.convertPositionToCommeo(targetPos);
         this.writeSerial(`<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>7</int><int>1</int><int>${commeoTargetPos}</int></array></methodCall>`, cb);
+    }
+    sendStop(device, cb) {
+        this.writeSerial(`<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>0</int><int>1</int><int>0</int></array></methodCall>`, cb);
+    }
+    sendMoveIntermediatePosition(device, pos, cb) {
+        this.writeSerial(`<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>${pos === 1 ? 3 : 5}</int><int>1</int><int>0</int></array></methodCall>`, cb);
     }
     requestUpdate(device, cb) {
         this.writeSerial(`<methodCall><methodName>selve.GW.device.getValues</methodName><array><int>${device}</int></array></methodCall>`, cb);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2017,9 +2017,9 @@
       }
     },
     "rxjs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
-      "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
+      "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -2338,9 +2338,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
       "dev": true
     },
     "tunnel-agent": {

--- a/src/data/commeo-state.ts
+++ b/src/data/commeo-state.ts
@@ -3,14 +3,12 @@ export class CommeoState {
     TargetPosition: number; // percentage 0 - 100, READ, WRITE, NOTIFY
     PositionState: HomebridgePositionState; // READ, NOTIFY
     ObstructionDetected: boolean; // READ, NOTIFY
-    device: number;
 
-    constructor(device: number) {
+    constructor() {
         this.CurrentPosition = 100; // assume default open
         this.TargetPosition = 100; // assume default open
         this.PositionState = HomebridgePositionState.STOPPED;
         this.ObstructionDetected = false;
-        this.device = device;
     }
 }
 

--- a/src/data/selve-config.ts
+++ b/src/data/selve-config.ts
@@ -3,4 +3,6 @@ import { AccessoryConfig } from 'homebridge';
 export interface SelveShutterAcessoryConfig extends AccessoryConfig {
     port?: string,
     device?: number,
+    showIntermediate1?: boolean,
+    showIntermediate2?: boolean
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,12 +7,12 @@ import {
   CharacteristicValue,
   HAP,
   Logging,
-  Service,
+  Service
 } from 'homebridge';
-
 import { CommeoState, HomebridgePositionState } from './data/commeo-state';
 import { SelveShutterAcessoryConfig } from './data/selve-config';
 import { USBRfService } from './util/usb-rf.service';
+
 
 let hap: HAP;
 
@@ -26,33 +26,41 @@ class SelveShutter implements AccessoryPlugin {
   private readonly usbService: USBRfService;
   private readonly informationService: Service;
   private readonly shutterService: Service;
+  private readonly switchService1: Service;
+  private readonly switchService2: Service;
   private readonly device: number;
   private readonly name: string;
+  private readonly config: SelveShutterAcessoryConfig;
   private state: CommeoState;
 
   constructor(log: Logging, config: SelveShutterAcessoryConfig, api: API) {
     this.log = log;
     this.name = config.name;
+    this.config = config;
 
     // device config
     this.device = Number(config.device);
     if (this.device === undefined) {
-      throw new Error('Option "device" needs to be set');
+      throw new Error('Option "device" is required and needs to be set!');
     }
 
     // serial port config
     const port = config.port;
     if (port === undefined) {
-      throw new Error('Option "port" needs to be set');
+      throw new Error('Option "port" is required and needs to be set!');
     }
 
     this.state = new CommeoState(this.device);
 
-    // setup services
+    // initialize services
     this.usbService = USBRfService.getInstance(port);
+
     this.shutterService = new hap.Service.WindowCovering(this.name);
     this.informationService = new hap.Service.AccessoryInformation();
+    this.switchService1 = new hap.Service.StatelessProgrammableSwitch(this.name);
+    this.switchService2 = new hap.Service.StatelessProgrammableSwitch(this.name);
 
+    // setup shutter services
     this.shutterService
       .getCharacteristic(hap.Characteristic.CurrentPosition)
       .on(CharacteristicEventTypes.GET, this.getCurrentPosition.bind(this));
@@ -70,6 +78,14 @@ class SelveShutter implements AccessoryPlugin {
       .getCharacteristic(hap.Characteristic.ObstructionDetected)
       .on(CharacteristicEventTypes.GET, this.getObstructionDetected.bind(this));
 
+    // setup optional intermediate button services
+    this.switchService1
+      .getCharacteristic(hap.Characteristic.ProgrammableSwitchEvent)
+      .on(CharacteristicEventTypes.SET, this.setIntermediatePosition(1).bind(this))
+
+    this.switchService2
+      .getCharacteristic(hap.Characteristic.ProgrammableSwitchEvent)
+      .on(CharacteristicEventTypes.SET, this.setIntermediatePosition(2).bind(this))
 
     // setup info service
     this.informationService = new hap.Service.AccessoryInformation();
@@ -103,25 +119,35 @@ class SelveShutter implements AccessoryPlugin {
       }
     });
 
-    // get current position
+    // request current position
     this.usbService.requestUpdate(this.device, err => !!err && log.error(err.message));
   }
 
-  public getServices(): Service[] {
+  public getServices(): Array<Service> {
     return [
       this.informationService,
       this.shutterService,
-    ];
+      this.config.showIntermediate1 ? this.switchService1 : null,
+      this.config.showIntermediate2 ? this.switchService2 : null
+    ].filter(s => !!s) as Array<Service>;
   }
-
 
   private getCurrentPosition = (cb: CharacteristicGetCallback<number>) => cb(null, this.state.CurrentPosition);
   private getTargetPosition = (cb: CharacteristicGetCallback<number>) => cb(null, this.state.TargetPosition);
   private setTargetPosition = (newPosition: CharacteristicValue, cb: CharacteristicSetCallback) => {
     this.log("Set new target position to", newPosition);
     this.state.TargetPosition = Number(newPosition);
-    this.usbService.sendPosition(this.state.device, this.state.TargetPosition, cb)
+    this.usbService.sendMovePosition(this.state.device, this.state.TargetPosition, cb)
   };
+  private setIntermediatePosition = (pos: 1 | 2) => (value: CharacteristicValue, cb: CharacteristicSetCallback) => {
+    if (!value) {
+      return cb();
+    }
+
+    this.log("Set to move to intermediate position", pos);
+    this.usbService.sendMoveIntermediatePosition(this.state.device, pos, cb);
+  };
+
   private getPositionState = (cb: CharacteristicGetCallback<HomebridgePositionState>) => cb(null, this.state.PositionState);
   private getObstructionDetected = (cb: CharacteristicGetCallback<boolean>) => cb(null, this.state.ObstructionDetected);
 }

--- a/src/util/usb-rf.service.ts
+++ b/src/util/usb-rf.service.ts
@@ -1,10 +1,10 @@
 import events from 'events';
 import xmlParser from 'fast-xml-parser';
 import SerialPort from 'serialport';
-
 import { CommeoState, HomebridgePositionState } from '../data/commeo-state';
 import { ErrorValueCallback } from '../data/error-value.callback';
 import { SeqqueueTask } from '../data/seqqueue-task';
+
 
 const seqqueue = require('seq-queue');
 const queue = seqqueue.createQueue(100);
@@ -115,10 +115,17 @@ export class USBRfService {
         return homekitPos > 0 ? COMMEO_MAX_POSITION - Math.min(Math.round(homekitPos / 100 * COMMEO_MAX_POSITION), COMMEO_MAX_POSITION) : COMMEO_MAX_POSITION;
     }
 
-    public sendPosition(device: number, targetPos: number, cb: ErrorValueCallback): void {
+    public sendMovePosition(device: number, targetPos: number, cb: ErrorValueCallback): void {
         const commeoTargetPos = this.convertPositionToCommeo(targetPos);
         this.writeSerial(
             `<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>7</int><int>1</int><int>${commeoTargetPos}</int></array></methodCall>`,
+            cb
+        );
+    }
+
+    public sendMoveIntermediatePosition(device: number, pos: 1 | 2, cb: ErrorValueCallback): void {
+        this.writeSerial(
+            `<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>${pos === 1 ? 3 : 5}</int><int>1</int><int>0</int></array></methodCall>`,
             cb
         );
     }

--- a/src/util/usb-rf.service.ts
+++ b/src/util/usb-rf.service.ts
@@ -123,6 +123,13 @@ export class USBRfService {
         );
     }
 
+    public sendStop(device: number, cb: ErrorValueCallback): void {
+        this.writeSerial(
+            `<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>0</int><int>1</int><int>0</int></array></methodCall>`,
+            cb
+        );
+    }
+
     public sendMoveIntermediatePosition(device: number, pos: 1 | 2, cb: ErrorValueCallback): void {
         this.writeSerial(
             `<methodCall><methodName>selve.GW.command.device</methodName><array><int>${device}</int><int>${pos === 1 ? 3 : 5}</int><int>1</int><int>0</int></array></methodCall>`,


### PR DESCRIPTION
This MR adds experimental support for intermediate positions.

It adds two new config options (`showIntermediate1` and `showIntermediate2`) which control visibility of two toggle buttons to allow moving a shutter to a predetermined intermediate position (namely position 1 or 2).

Based on feature request #5